### PR TITLE
Remove stylelint warnings in js/jsx files in vs code

### DIFF
--- a/.stylelintrc
+++ b/.stylelintrc
@@ -5,5 +5,9 @@
     "selector-class-pattern": null,
     "no-descending-specificity": null,
     "selector-max-compound-selectors": 3
-  }
+  },
+  "ignoreFiles": [
+    "**/*.jsx",
+    "**/*.js"
+  ]
 }


### PR DESCRIPTION
Stylelint extension in vs code scans js/jsx files and issues warnings